### PR TITLE
Consider ordering of tag-value pairs; ignore unknown tags

### DIFF
--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -54,6 +54,20 @@ describe Parser do
       )
     end
 
+    it "parses yahoo's dmarc record (as of 2014/08/12)" do
+      record = 'v=DMARC1; p=reject; sp=none; pct=100; rua=mailto:dmarc-yahoo-rua@yahoo-inc.com, mailto:dmarc_y_rua@yahoo.com;'
+      expect(subject.parse record).to eq(
+        v: 'DMARC1',
+        p: 'reject',
+        sp: 'none',
+        pct: '100',
+        rua: [
+          {uri: 'mailto:dmarc-yahoo-rua@yahoo-inc.com'},
+          {uri: 'mailto:dmarc_y_rua@yahoo.com'}
+        ]
+      )
+    end
+
     it 'ignores spacing' do
       record1 = 'v=DMARC1;p=none;sp=reject'
       record2 = 'v = DMARC1 ; p = none ; sp = reject'


### PR DESCRIPTION
From the spec:

```
A DMARC policy record MUST comply with the formal specification found
in Section 5.3 in that the "v" and "p" tags MUST be present and MUST
appear in that order.  Unknown tags MUST be ignored.  Syntax errors
in the remainder of the record SHOULD be discarded in favor of
default values (if any) or ignored outright.
```

We are currently enforcing the order of all of the tags (not just v and p).  We also blow up on unknown tags.

I've added a failing test with yahoo's dmarc record as an example of the `pct` tag being out of order.
