### PR TITLE
Fix bad require for dmarc/errors

### DIFF
--- a/lib/dmarc.rb
+++ b/lib/dmarc.rb
@@ -1,4 +1,4 @@
-require 'dmarc/errors'
+require 'dmarc/exceptions'
 require 'dmarc/record'
 require 'dmarc/parser'
 require 'dmarc/version'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'rspec'
-require 'dmarc/version'
+require 'dmarc'
 
 include DMARC
 


### PR DESCRIPTION
I also changed the test suite to try to `require 'dmarc'` as that's our integration point with the rest of the world.
