### PR TITLE
DMARC Record headers are now attr_accessor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
   - ruby-head
   - jruby
 matrix:

--- a/dmarc.gemspec
+++ b/dmarc.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'parslet', '~> 1.5'
 
-  gem.add_development_dependency 'bundler', '~> 1.0'
+  gem.add_development_dependency 'bundler'
 end

--- a/lib/dmarc/record.rb
+++ b/lib/dmarc/record.rb
@@ -10,27 +10,27 @@ module DMARC
     # `p` field.
     # 
     # @return [:none, :quarantine, :reject]
-    attr_writer :p
+    attr_accessor :p
 
     # `rua` field.
     #
     # @return [Array<Uri>]
-    attr_writer :rua
+    attr_accessor :rua
 
     # `rua` field.
     #
     # @return [Array<Uri>]
-    attr_writer :ruf
+    attr_accessor :ruf
 
     # `sp` field.
     # 
     # @return [:none, :quarantine, :reject]
-    attr_writer :sp
+    attr_accessor :sp
 
     # `v` field.
     #
     # @return [:DMARC1]
-    attr_writer :v
+    attr_accessor :v
 
     #
     # Initializes the record.

--- a/lib/dmarc/record.rb
+++ b/lib/dmarc/record.rb
@@ -10,27 +10,27 @@ module DMARC
     # `p` field.
     # 
     # @return [:none, :quarantine, :reject]
-    attr_reader :p
+    attr_writer :p
 
     # `rua` field.
     #
     # @return [Array<Uri>]
-    attr_reader :rua
+    attr_writer :rua
 
     # `rua` field.
     #
     # @return [Array<Uri>]
-    attr_reader :ruf
+    attr_writer :ruf
 
     # `sp` field.
     # 
     # @return [:none, :quarantine, :reject]
-    attr_reader :sp
+    attr_writer :sp
 
     # `v` field.
     #
     # @return [:DMARC1]
-    attr_reader :v
+    attr_writer :v
 
     #
     # Initializes the record.


### PR DESCRIPTION
DMARC Record headers are changed form attr_reader to attr_accessor, so that we can also generator Dmarc headers, does not matter if we are receiving certain attribute from previous header or not.