### PR TITLE
allow trailing whitespace after missing final sep

### DIFF
--- a/lib/dmarc/parser.rb
+++ b/lib/dmarc/parser.rb
@@ -16,7 +16,8 @@ module DMARC
     rule(:dmarc_record) do
       dmarc_version.repeat(1,1) >>
       (dmarc_sep >> dmarc_tag).repeat >>
-      dmarc_sep.maybe
+      dmarc_sep.maybe >>
+      wsp?.maybe
     end
 
     rule(:dmarc_sep) { wsp? >> str(';') >> wsp? }

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -80,6 +80,15 @@ describe Parser do
         ])
       end
 
+      it 'ignores trailing spacing without final separator' do
+        record = 'v=DMARC1; p=none '
+
+        expect(subject.parse(record)).to eq([
+          {v: 'DMARC1'},
+          {p: 'none'}
+        ])
+      end
+
       it "ignores unknown tags" do
         record = 'v=DMARC1;p=none;foo=xxx;sp=reject;bar=xxx;adkim=r;aspf=r'
         expect(subject.parse(record)).to eq([


### PR DESCRIPTION
The spec allows both an optional final separator and optional trailing whitespace but this combination is currently throwing the `DMARC::InvalidRecord` error.

Before changes:
```
irb(main):005> DMARC::Record.parse("v=DMARC1; p=reject ")
/usr/local/bundle/gems/dmarc-0.5.0/lib/dmarc/record.rb:276:in `rescue in parse': Failed to match sequence (DMARC_VERSION{1, 1} (DMARC_SEP DMARC_TAG){0, } DMARC_SEP?) at line 1 char 19. (DMARC::InvalidRecord)
```

After changes:
```
irb(main):005> DMARC::Record.parse("v=DMARC1; p=reject ")
{:v=>"DMARC1"@2}
{:p=>"none"@12}
```