### PR TITLE
Case-insensitive version tags (#24)

### DIFF
--- a/lib/dmarc/parser.rb
+++ b/lib/dmarc/parser.rb
@@ -23,7 +23,7 @@ module DMARC
     rule(:dmarc_sep) { wsp? >> str(';') >> wsp? }
 
     rule(:dmarc_version) do
-      str('v') >> wsp? >>
+      match('[vV]') >> wsp? >>
       str('=') >> wsp? >>
       str('DMARC1').as(:v)
     end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -119,6 +119,10 @@ describe Parser do
       it 'ignores spacing' do
         expect(subject.parse 'v = DMARC1').to eq(subject.parse 'v=DMARC1')
       end
+
+      it 'ignores tag case' do
+        expect(subject.parse('V=DMARC1')).to eq(v: 'DMARC1')
+      end
     end
 
     describe 'dmarc_request' do


### PR DESCRIPTION
Fix #24, allowing case insensitive `v=` / `V=` tag name.

I *think* that this could be generalized to all tag names per the spec, but I'm not 100% sure. I'd like to start with that, and if that's acceptable, we could generalize the approach? Sounds like a topic ripe for bike-shedding. 😅

Note that [RFC 7489](https://datatracker.ietf.org/doc/html/rfc7489) does not seem to mention case-sensitiveness at any point, and uses lower-case `v=` in the [formal definition](https://datatracker.ietf.org/doc/html/rfc7489#section-6.4). The only place I found a mention of it is on this [2016 blog post](https://dmarc.org/2016/07/common-problems-with-dmarc-records/) (look for: "Legal Constructs That Might Not Be Recognized"), where the author wrote:

> The string “DMARC” is the only portion of the DMARC policy record that is case-sensitive, but it is not uncommon for people reading the specification to miss this fact. For best results, keep everything but “DMARC” lower case.

With that in mind, I think it's also good to be a little relaxed in what a parser accepts.